### PR TITLE
Possibility to fail build on drush errors

### DIFF
--- a/DrushTask.php
+++ b/DrushTask.php
@@ -62,6 +62,7 @@ class DrushTask extends Task {
   private $bin = NULL;
   private $uri = NULL;
   private $root = NULL;
+  private $site_alias = NULL;
   private $assume = NULL;
   private $simulate = FALSE;
   private $pipe = FALSE;
@@ -91,6 +92,10 @@ class DrushTask extends Task {
    */
   public function setRoot($str) {
     $this->root = $str;
+  }
+
+  public function setSiteAlias($str) {
+    $this->site_alias = $str;
   }
 
   /**
@@ -198,6 +203,7 @@ class DrushTask extends Task {
     $this->root = $this->getProject()->getProperty('drush.root');
     $this->uri = $this->getProject()->getProperty('drush.uri');
     $this->bin = $this->getProject()->getProperty('drush.bin');
+    $this->site_alias = $this->getProject()->getProperty('drush.site_alias');
   }
 
   /**
@@ -212,7 +218,13 @@ class DrushTask extends Task {
     $option->setName('nocolor');
     $this->options[] = $option;
 
-    if (!empty($this->root)) {
+    if (!empty($this->site_alias)) {
+      $option = new DrushOption();
+      $option->addText($this->site_alias);
+      $this->options[] = $option;
+    }
+
+    if (!empty($this->root) && empty($this->site_alias)) {
       $option = new DrushOption();
       $option->setName('root');
       $option->addText($this->root);

--- a/DrushTask.php
+++ b/DrushTask.php
@@ -265,10 +265,10 @@ class DrushTask extends Task {
     // Execute Drush.
     $this->log("Executing '$command'...");
     $output = array();
-    exec($command, $output, $return);
+    exec($command . ' 2>&1', $output, $return);
     // Collect Drush output for display through Phing's log.
     foreach ($output as $line) {
-      if ($this->haltonerror && preg_match_all('/Drush command terminated abnormally due to an unrecoverable error./', $line)) {
+      if ($this->haltonerror && strpos($line, 'Drush command terminated abnormally due to an unrecoverable error.') !== FALSE) {
         throw new BuildException("Drush command terminated abnormally due to an unrecoverable error.");
       }
       $this->log($line);

--- a/DrushTask.php
+++ b/DrushTask.php
@@ -219,9 +219,9 @@ class DrushTask extends Task {
     $this->options[] = $option;
 
     if (!empty($this->site_alias)) {
-      $option = new DrushOption();
-      $option->addText($this->site_alias);
-      $this->options[] = $option;
+      $param = new DrushParam();
+      $param->addText($this->site_alias);
+      $command[] = $param->getValue();
     }
 
     if (!empty($this->root) && empty($this->site_alias)) {

--- a/DrushTask.php
+++ b/DrushTask.php
@@ -268,6 +268,9 @@ class DrushTask extends Task {
     exec($command, $output, $return);
     // Collect Drush output for display through Phing's log.
     foreach ($output as $line) {
+      if ($this->haltonerror && preg_match_all('/Drush command terminated abnormally due to an unrecoverable error./', $line)) {
+        throw new BuildException("Drush command terminated abnormally due to an unrecoverable error.");
+      }
       $this->log($line);
     }
     // Set value of the 'pipe' property.

--- a/DrushTask.php
+++ b/DrushTask.php
@@ -268,10 +268,10 @@ class DrushTask extends Task {
     exec($command . ' 2>&1', $output, $return);
     // Collect Drush output for display through Phing's log.
     foreach ($output as $line) {
+      $this->log($line);
       if ($this->haltonerror && strpos($line, 'Drush command terminated abnormally due to an unrecoverable error.') !== FALSE) {
         throw new BuildException("Drush command terminated abnormally due to an unrecoverable error.");
       }
-      $this->log($line);
     }
     // Set value of the 'pipe' property.
     if (!empty($this->return_property)) {


### PR DESCRIPTION
We had a case where simpletests would pass without errors, even though drush exited unsuccessfully during the tests due to a fatal error. These changes fix this.
